### PR TITLE
Upgrade Sidekiq to avoid redis-rb related warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'rails-i18n', '~> 6.0'
 gem 'react-rails'
 gem 'webpacker'
 
-gem 'sidekiq'
+gem 'sidekiq', '6.4.2' # To avoid warnings from redis-rb.
 
 gem 'paper_trail'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,8 @@ GIT
     mimemagic (0.3.5)
 
 GEM
-  remote: https://rails-assets.org/
-  specs:
-    rails-assets-momentjs (2.22.2)
-
-GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actioncable (6.1.4.7)
       actionpack (= 6.1.4.7)
@@ -345,7 +341,7 @@ GEM
     pundit (2.1.1)
       activesupport (>= 3.0.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
     rack-protection (2.1.0)
@@ -370,6 +366,7 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.4.7)
       sprockets-rails (>= 2.0.0)
+    rails-assets-momentjs (2.22.2)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -453,7 +450,7 @@ GEM
       ruby_http_client (~> 3.4)
     sexp_processor (4.15.3)
     shellany (0.0.1)
-    sidekiq (6.4.0)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -571,7 +568,7 @@ DEPENDENCIES
   selectize-rails
   selenium-webdriver
   sendgrid-ruby
-  sidekiq
+  sidekiq (= 6.4.2)
   simple_form
   spring
   spring-commands-rspec


### PR DESCRIPTION
```
2022-06-21T13:22:09.277127+00:00 app[worker.1]: Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
2022-06-21T13:22:09.277137+00:00 app[worker.1]:
2022-06-21T13:22:09.277138+00:00 app[worker.1]: redis.multi do
2022-06-21T13:22:09.277138+00:00 app[worker.1]: redis.get("key")
2022-06-21T13:22:09.277139+00:00 app[worker.1]: end
2022-06-21T13:22:09.277139+00:00 app[worker.1]:
2022-06-21T13:22:09.277140+00:00 app[worker.1]: should be replaced by
2022-06-21T13:22:09.277141+00:00 app[worker.1]:
2022-06-21T13:22:09.277141+00:00 app[worker.1]: redis.multi do |pipeline|
2022-06-21T13:22:09.277141+00:00 app[worker.1]: pipeline.get("key")
2022-06-21T13:22:09.277142+00:00 app[worker.1]: end
2022-06-21T13:22:09.277142+00:00 app[worker.1]:
2022-06-21T13:22:09.277143+00:00 app[worker.1]: (called from /app/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.4.0/lib/sidekiq/launcher.rb:141:in `block in ❤'}
```