### PR TITLE
Set redis gem version to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'react-rails'
 gem 'webpacker'
 
 gem 'sidekiq'
-gem 'redis'
+gem 'redis', "~> 4.0"
 
 gem 'paper_trail'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     chartkick (5.0.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
-    connection_pool (2.3.0)
+    connection_pool (2.4.1)
     countries (5.3.1)
       unaccent (~> 0.3)
     country_select (8.0.1)
@@ -413,9 +413,8 @@ GEM
       railties (>= 3.2)
       tilt
     redcarpet (3.6.0)
-    redis (5.0.7)
-      redis-client (>= 0.9.0)
-    redis-client (0.12.1)
+    redis (4.8.1)
+    redis-client (0.16.0)
       connection_pool
     regexp_parser (2.7.0)
     request_store (1.5.1)
@@ -601,7 +600,7 @@ DEPENDENCIES
   rails-i18n (~> 6.0)
   react-rails
   redcarpet (~> 3.5)
-  redis
+  redis (~> 4.0)
   rexml
   rspec
   rspec-rails


### PR DESCRIPTION
Action Cable requires redis gem v4 family