### PR TITLE
Sync proposal and program_session

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -109,6 +109,7 @@ class ProposalsController < ApplicationController
   def update
     if params[:confirm]
       @proposal.update(confirmed_at: Time.current)
+      @proposal.sync_program_session
       redirect_to event_event_proposals_url(slug: @event.slug, uuid: @proposal), flash: { success: "Thank you for confirming your participation" }
     elsif @proposal.speaker_update_and_notify(proposal_params)
       redirect_to event_proposal_url(event_slug: @event.slug, uuid: @proposal)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -39,7 +39,6 @@ class Proposal < ApplicationRecord
 
   before_create :set_uuid, :set_updated_by_speaker_at
   before_update :save_attr_history
-  after_update :update_program_session
   after_save :save_tags, :save_review_tags
 
   scope :accepted, -> { where(state: ACCEPTED) }
@@ -243,6 +242,7 @@ class Proposal < ApplicationRecord
     old_title = title
     speaker_updates = attributes.merge({ updated_by_speaker_at: Time.current })
     if update(speaker_updates)
+      sync_program_session
       field_names = last_change.join(', ')
       reviewers.each do |reviewer|
         Notification.create_for(reviewer, proposal: self,
@@ -287,7 +287,7 @@ class Proposal < ApplicationRecord
   # the associated program_session becomes outdated. Consequently, the program.json also becomes outdated.
   # Strictly, organizers should prohibit speakers from editing their submitted proposals directly.
   # However, for practical reasons, we allow modifications by speakers.
-  def update_program_session
+  def sync_program_session
     if program_session.present?
       program_session.update!(title: title, abstract: abstract)
     end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -162,5 +162,26 @@ describe ProposalsController, type: :controller do
                       pitch: 'new_pitch' }}
       }.to change { Notification.count }.by(1)
     end
+
+    context "when the proposal approved (has program_session)" do
+      let!(:program_session) { create(:program_session, proposal: proposal, track: proposal.track, speakers: [speaker]) }
+
+      before do
+        proposal.update(title: 'orig_title', abstract: "orig_abst", pitch: 'orig_pitch')
+        program_session.update(title: 'orig_title', abstract: "orig_abst")
+      end
+
+      it "updates the program_session attributes also" do
+        put :update, params: {event_slug: proposal.event.slug, uuid: proposal,
+          proposal: { title: 'new_title', abstract: 'new_abst', pitch: 'new_pitch' }}
+
+      proposal.reload
+      program_session.reload
+      expect(proposal.title).to eq('new_title')
+      expect(proposal.pitch).to eq('new_pitch')
+      expect(program_session.title).to eq('new_title')
+      expect(program_session.abstract).to eq('new_abst')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What and why

When a speaker makes minor changes to their submitted proposal (such as fixing a typo), the associated program_session becomes outdated.
Consequently, the program.json also becomes outdated.

Strictly, organizers should prohibit speakers from editing their submitted proposals directly. However, for practical reasons, we allow modifications by speakers.