### PR TITLE
Add fallback codeblock render when coderay fails highlighting

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,6 +21,14 @@ module ApplicationHelper
     def block_code(code, language)
       language ||= :ruby
       CodeRay.highlight(code, language)
+    rescue
+      <<~HTML
+        <div class="CodeRay">
+          <div class="code">
+            <pre>#{ERB::Util.html_escape(code)}</pre>
+          </div>
+        </div>
+      HTML
     end
   end
 


### PR DESCRIPTION
## Why
Handle code block with wrong lang tag like that


````
```unexistedlanguage
abcde
```
````